### PR TITLE
Error reporting/params with no error

### DIFF
--- a/examples/auto_time_series_example.py
+++ b/examples/auto_time_series_example.py
@@ -21,7 +21,7 @@ def main():
     # Create connection to Decanter server, and set up basic settings.
     # Logger message:
     #   "[Context] connect healty :)" if success.
-    client = core.CoreClient(username='gp', password='gp-admin', host='http://192.168.2.6:2999')
+    client = core.CoreClient(username='gp', password='gp-admin', host='http://localhost:3000')
 
     train_file_path = 'data/ts_data/iris_train.csv'
     test_file_path = 'data/ts_data/iris_test.csv'
@@ -44,7 +44,7 @@ def main():
     train_input = TrainTSInput(
         data=train_data, target='regression', forecast_horizon=7, gap=0, algorithms=["XGBoost"],
         datetime_column='date', max_model=1, evaluator=Evaluator.r2, time_unit='day',
-        max_iteration=10, numerical_groupby_method='mean', holdout_percentage=0.05)
+        max_iteration=10, numerical_groupby_method='mean')
 
     # Start train time series models.
     exp_ts = client.train_ts(train_input=train_input, select_model_by=Evaluator.r2, name='ExpTS')

--- a/examples/auto_time_series_example.py
+++ b/examples/auto_time_series_example.py
@@ -21,7 +21,7 @@ def main():
     # Create connection to Decanter server, and set up basic settings.
     # Logger message:
     #   "[Context] connect healty :)" if success.
-    client = core.CoreClient(username='gp', password='gp-admin', host='http://localhost:3000')
+    client = core.CoreClient(username='gp', password='gp-admin', host='http://192.168.2.6:2999')
 
     train_file_path = 'data/ts_data/iris_train.csv'
     test_file_path = 'data/ts_data/iris_test.csv'
@@ -44,7 +44,7 @@ def main():
     train_input = TrainTSInput(
         data=train_data, target='regression', forecast_horizon=7, gap=0, algorithms=["XGBoost"],
         datetime_column='date', max_model=1, evaluator=Evaluator.r2, time_unit='day',
-        max_iteration=10, numerical_groupby_method='mean')
+        max_iteration=10, numerical_groupby_method='mean', holdout_percentage=0.05)
 
     # Start train time series models.
     exp_ts = client.train_ts(train_input=train_input, select_model_by=Evaluator.r2, name='ExpTS')

--- a/src/decanter/core/core_api/train_input.py
+++ b/src/decanter/core/core_api/train_input.py
@@ -136,7 +136,6 @@ class TrainTSInput:
         build_spec = CoreBody.BuildSpec.create(
             tolerance=tolerance,
             validation_percentage=validation_percentage,
-            holdout_percentage=holdout_percentage,
             max_model=max_model,
             seed=seed,
             evaluator=evaluator,
@@ -161,7 +160,8 @@ class TrainTSInput:
             feature_types=feature_types,
             time_groups=time_groups,
             max_window_for_feature_derivation=max_window_for_feature_derivation,
-            group_by=group_by
+            group_by=group_by,
+            holdout_percentage=holdout_percentage
         )
 
         self.train_auto_ts_body = CoreBody.TrainAutoTSBody.create(

--- a/src/decanter/core/core_api/train_input.py
+++ b/src/decanter/core/core_api/train_input.py
@@ -9,6 +9,8 @@ from decanter.core.core_api import CoreAPI
 from decanter.core.core_api import CoreBody
 from decanter.core.enums.algorithms import Algo
 from decanter.core.enums.evaluators import Evaluator
+from decanter.core.enums.time_units import TimeUnit
+from decanter.core.enums.numerical_group_by_methods import NumericalGroupByMethod
 from decanter.core.enums import check_is_enum
 
 class TrainInput:
@@ -121,6 +123,8 @@ class TrainTSInput:
             time_groups=None, max_window_for_feature_derivation=None):
 
         evaluator = check_is_enum(Evaluator, evaluator)
+        time_unit = check_is_enum(TimeUnit, time_unit)
+        numerical_groupby_method = check_is_enum(NumericalGroupByMethod, numerical_groupby_method)
         self.data = data
 
         geneticAlgorithm = CoreBody.GeneticAlgorithmParams.create(

--- a/src/decanter/core/core_api/train_input.py
+++ b/src/decanter/core/core_api/train_input.py
@@ -11,6 +11,7 @@ from decanter.core.enums.algorithms import Algo
 from decanter.core.enums.evaluators import Evaluator
 from decanter.core.enums.time_units import TimeUnit
 from decanter.core.enums.numerical_group_by_methods import NumericalGroupByMethod
+from decanter.core.enums.categorical_group_by_method import CategoricalGroupByMethod
 from decanter.core.enums import check_is_enum
 
 class TrainInput:
@@ -125,6 +126,7 @@ class TrainTSInput:
         evaluator = check_is_enum(Evaluator, evaluator)
         time_unit = check_is_enum(TimeUnit, time_unit)
         numerical_groupby_method = check_is_enum(NumericalGroupByMethod, numerical_groupby_method)
+        categorical_groupby_method = check_is_enum(CategoricalGroupByMethod, categorical_groupby_method)
         self.data = data
 
         geneticAlgorithm = CoreBody.GeneticAlgorithmParams.create(

--- a/src/decanter/core/enums/__init__.py
+++ b/src/decanter/core/enums/__init__.py
@@ -3,6 +3,7 @@ from .evaluators import Evaluator
 from .algorithms import Algo
 from .time_units import TimeUnit
 from .numerical_group_by_methods import NumericalGroupByMethod
+from .categorical_group_by_method import CategoricalGroupByMethod
 
 # checks if enum is enumerated in Enum
 # Throws AttributeError if not in Enum; returns enum as str otherwise

--- a/src/decanter/core/enums/__init__.py
+++ b/src/decanter/core/enums/__init__.py
@@ -1,6 +1,8 @@
 """Init jobs package"""
 from .evaluators import Evaluator
 from .algorithms import Algo
+from .time_units import TimeUnit
+from .numerical_group_by_methods import NumericalGroupByMethod
 
 # checks if enum is enumerated in Enum
 # Throws AttributeError if not in Enum; returns enum as str otherwise

--- a/src/decanter/core/enums/categorical_group_by_method.py
+++ b/src/decanter/core/enums/categorical_group_by_method.py
@@ -1,0 +1,6 @@
+'''available categorical group by methods supported by corex'''
+from enum import Enum
+
+class CategoricalGroupByMethod(Enum):
+    count = 'count'
+    mode = 'mode'

--- a/src/decanter/core/enums/numerical_group_by_methods.py
+++ b/src/decanter/core/enums/numerical_group_by_methods.py
@@ -1,0 +1,7 @@
+'''available numerical group by methods supported by corex'''
+import enum as Enum
+
+class NumericalGroupByMethod(Enum):
+    SUM = 'sum'
+    MEAN = 'mean'
+    COUNT = 'count'

--- a/src/decanter/core/enums/numerical_group_by_methods.py
+++ b/src/decanter/core/enums/numerical_group_by_methods.py
@@ -4,4 +4,3 @@ from enum import Enum
 class NumericalGroupByMethod(Enum):
     sum = 'sum'
     mean = 'mean'
-    count = 'count'

--- a/src/decanter/core/enums/numerical_group_by_methods.py
+++ b/src/decanter/core/enums/numerical_group_by_methods.py
@@ -1,7 +1,7 @@
 '''available numerical group by methods supported by corex'''
-import enum as Enum
+from enum import Enum
 
 class NumericalGroupByMethod(Enum):
-    SUM = 'sum'
-    MEAN = 'mean'
-    COUNT = 'count'
+    sum = 'sum'
+    mean = 'mean'
+    count = 'count'

--- a/src/decanter/core/enums/time_units.py
+++ b/src/decanter/core/enums/time_units.py
@@ -2,7 +2,7 @@
 from enum import Enum
 
 class TimeUnit(Enum):
-    HOUR = 'hour'
-    DAY = 'day'
-    MONTH = 'month'
-    YEAR = 'year'
+    hour = 'hour'
+    day = 'day'
+    month = 'month'
+    year = 'year'

--- a/src/decanter/core/enums/time_units.py
+++ b/src/decanter/core/enums/time_units.py
@@ -1,0 +1,8 @@
+'''valid time units that are currently supported by corex'''
+from enum import Enum
+
+class TimeUnit(Enum):
+    HOUR = 'hour'
+    DAY = 'day'
+    MONTH = 'month'
+    YEAR = 'year'

--- a/src/decanter/core/extra/utils.py
+++ b/src/decanter/core/extra/utils.py
@@ -13,7 +13,7 @@ def check_response(response, key=None):
     """
     code = response.status_code
     if not 200 <= code < 300:
-        raise Exception('[Decanter Core response Error] Request Error')
+        raise Exception(f'[Decanter Core response Error] Request Error: {response.text}')
 
     if key is not None and key not in response.json():
         raise KeyError('[Decanter Core response Error] No key value')

--- a/src/decanter/core/extra/utils.py
+++ b/src/decanter/core/extra/utils.py
@@ -18,6 +18,10 @@ def check_response(response, key=None):
     if key is not None and key not in response.json():
         raise KeyError('[Decanter Core response Error] No key value')
 
+    if 'error' in response.json():
+        raise Exception(
+            f"[Decanter Core response Error] Request Error: {response.json()['error']['description']}")
+
     return response
 
 


### PR DESCRIPTION
Added detailed error reporting in SDK for 3 types of corex responses:
1. internal server error: These cause the event loop to fail immediately before training begins, caused by bogus values in forecast horizon, nfold, validation, and holdout percentage. Previously, they all resulted in the generic "Internal server error" in the check_response method in utils.py. Now a more detailed description of the error is raised.
(Note: previously, holdout percentage was mistakenly placed in build_spec instead of input_spec in the TrainTSInput class. This is fixed in this pull request)
2. "non-internal server error" errors: These are errors reported in the response body from coreX and were not previously checked for since they are not internal server errors, cased by bogus values in target, gap, date time column, and max_window_for_feature_derivation. These errors do not halt the event loop, allowing training and prediction to continue until they inevitably fail. When they fail, the user is only notified that something went wrong in the prediction task, whereas in reality, it is training that failed. This is fixed by explicitly checking for these types of responses in check_response by seeing if the response body contains an 'error' field. If it does, the 'description' of the error is raised. Now the event loop is halted, and detailed error messages are logged depending on the bogus parameter.
3. errors that do not raise exceptions due to assumptions made by coreX: These are errors that went unchecked because of default values that are filled in by corex. As such, the user may not know that they are making mistakes in inputting data, and receive results that do not reflect their intentions. This is caused by bogus values in time_unit and numerical_groupby_method. This was fixed by adding enum classes for both time_unit and numerical_groupby_method so user input is checked as soon as a TrainTSInput class is instantiated, long before the event loop is started.