### PR TITLE
[hotfix][DE-5283] Remove unnecessary check and exception on check_response

### DIFF
--- a/src/decanter/core/extra/utils.py
+++ b/src/decanter/core/extra/utils.py
@@ -18,10 +18,6 @@ def check_response(response, key=None):
     if key is not None and key not in response.json():
         raise KeyError('[Decanter Core response Error] No key value')
 
-    if 'error' in response.json():
-        raise Exception(
-            f"[Decanter Core response Error] Request Error: {response.json()['error']['description']}")
-
     return response
 
 


### PR DESCRIPTION
The check inside check_response make some functions failed (Ex. data.show() or data.show_df())
Remove the check and also the exception. 
The exception on error here will cause CoreClient to crash and also unable to make any further requests successfully.