### PR TITLE
[BUGFIX] Correct get_best_model to work when select_model_by is auto

### DIFF
--- a/src/decanter/core/jobs/experiment.py
+++ b/src/decanter/core/jobs/experiment.py
@@ -111,7 +111,7 @@ class Experiment(Job):
                     Evaluator.rmsle.value, Evaluator.misclassification.value}
         best_model_id = None
         try:
-            if self.select_model_by in minlevel:
+            if select_by_evaluator in minlevel:
                 best_model_id = min(
                     model_list.values(),
                     key=lambda x: x['cv_averages'][select_by_evaluator])['model_id']


### PR DESCRIPTION
get_best_model used to get the id with maximum cv average wrongly when select_model_by is auto.
Correct get_best_model function so that it works properly when select_model_by is auto