### PR TITLE
Support train clustering experiment

### DIFF
--- a/src/decanter/core/core_api/__init__.py
+++ b/src/decanter/core/core_api/__init__.py
@@ -3,6 +3,6 @@ from . import body_obj as CoreBody
 from .api import CoreAPI
 from .model import Model, MultiModel
 from .predict_input import PredictInput, PredictTSInput
-from .train_input import TrainInput, TrainTSInput
+from .train_input import TrainInput, TrainTSInput, TrainClusterInput
 from .setup_input import SetupInput
 from .worker import Worker

--- a/src/decanter/core/core_api/api.py
+++ b/src/decanter/core/core_api/api.py
@@ -201,6 +201,16 @@ class CoreAPI:
         """
         return self.requests_(http='POST', url='/v2/tasks/train', json=kwargs, headers=self.corex_headers)
 
+    def post_tasks_cluster_train(self, **kwargs):
+        """Train model from data reference.
+
+        Endpoint: /v2/tasks/cluster_train
+
+        Returns:
+            class:`Response <Response>` object
+        """
+        return self.requests_(http='POST', url='/v2/tasks/cluster_train', json=kwargs, headers=self.corex_headers)
+
     def post_tasks_auto_ts_train(self, **kwargs):
         """Train time series forecast multi model from data reference.
 

--- a/src/decanter/core/core_api/body_obj.py
+++ b/src/decanter/core/core_api/body_obj.py
@@ -21,6 +21,7 @@ class ComplexEncoder(json.JSONEncoder):
     Returns:
         function: `jsonable`
     """
+
     def default(self, obj):
         if hasattr(obj, 'jsonable'):
             return obj.jsonable()
@@ -34,6 +35,7 @@ class CoreBodyObj:
     Has the jsonable function to return the Dictionary of object.
 
     """
+
     def __init__(self, **kwargs):
         """Add the argument pass in as attributes."""
         self.__dict__.update(
@@ -88,6 +90,15 @@ class TrainBody(CoreBodyObj):
     @corex_obj(required={'target', 'train_data_id', 'algos'})
     def create(cls, **kwargs):
         """Return TrainBody object with passed kwargs as attributes"""
+        return cls(**kwargs)
+
+
+class ClusterTrainBody(CoreBodyObj):
+    """ClusterTrainBody"""
+    @classmethod
+    @corex_obj(required={'train_data_id'})
+    def create(cls, **kwargs):
+        """Return ClusterTrainBody object with passed kwargs as attributes"""
         return cls(**kwargs)
 
 
@@ -157,6 +168,7 @@ class InputSpec(CoreBodyObj):
         """Return InputSpec object with passed kwargs as attributes"""
         return cls(**kwargs)
 
+
 class BuildSpec(CoreBodyObj):
     """Attribute for TrainAutoTSBody."""
     @classmethod
@@ -164,6 +176,7 @@ class BuildSpec(CoreBodyObj):
     def create(cls, **kwargs):
         """Return BuildSpec object with passed kwargs as attributes"""
         return cls(**kwargs)
+
 
 class TrainAutoTSBody(CoreBodyObj):
     """Body for auto time series train api."""
@@ -191,6 +204,7 @@ class PredictBodyTSModel(CoreBodyObj):
         """Return PredictBodyTSModel object with passed kwargs as attributes"""
         return cls(**kwargs)
 
+
 class SetupBody(CoreBodyObj):
     """Body for setup api."""
     @classmethod
@@ -199,6 +213,7 @@ class SetupBody(CoreBodyObj):
         """Return SetupBody object with passed kwargs as attributes"""
         return cls(**kwargs)
 
+
 class Accessor(CoreBodyObj):
     """Data accessor"""
     @classmethod
@@ -206,6 +221,7 @@ class Accessor(CoreBodyObj):
     def create(cls, **kwargs):
         """Return SetupBody object with passed kwargs as attributes"""
         return cls(**kwargs)
+
 
 def column_array(cols):
     """Turn Josn columns to list of Column objects."""

--- a/src/decanter/core/core_api/train_input.py
+++ b/src/decanter/core/core_api/train_input.py
@@ -57,6 +57,7 @@ class TrainInput:
             algos=Algo.XGBoost, max_model=2, tolerance=0.9)
 
     """
+
     def __init__(
             self, data, target, algos,
             callback=None, test_base_id=None, test_data_id=None,
@@ -174,6 +175,7 @@ class TrainTSInput:
         validation_percentage (float): Percentage of the train data to be used as the validation set.
         holdout_percentage (float): Percentage of the training data to be used as a holdout set.
     """
+
     def __init__(
             self, data, target, datetime_column, forecast_horizon, gap, algorithms=None, feature_types=None,
             callback=None, version='v2', max_iteration=None, generation_size=None,
@@ -204,7 +206,7 @@ class TrainTSInput:
             max_run_time=max_run_time,
             genetic_algorithm=geneticAlgorithm,
             nfold=nfold,
-            algos = algorithms # user specifies algorithm used in TS analysis
+            algos=algorithms  # user specifies algorithm used in TS analysis
         )
         group_by = CoreBody.TSGroupBy.create(
             time_unit=time_unit,
@@ -249,5 +251,51 @@ class TrainTSInput:
         """
         setattr(self.train_auto_ts_body.input_spec, 'train_data_id', self.data.id)
         params = json.dumps(self.train_auto_ts_body.jsonable(), cls=CoreBody.ComplexEncoder)
+        params = json.loads(params)
+        return params
+
+
+class TrainClusterInput:
+    """Train Input for Clustering Experiment Job.
+
+    Settings for model training.
+
+    Args:
+        data (:class:`~decanter.core.jobs.data_upload.DataUpload`):
+            Train data uploaded on Decanter Core server
+        features (list of str): selected feature for training
+        seed (int):
+            Seed to be used for operations that have sudo random behavior.
+            Fixing seed across runs will ensure reproducible results
+
+    Example:
+        .. code-block:: python
+
+            train_input = TrainClusterInput(data=train_data)
+
+    """
+
+    def __init__(
+            self, data, callback=None, features=None, feature_types=None, k=None, seed=None, version=None):
+
+        self.data = data
+
+        self.train_body = CoreBody.ClusterTrainBody.create(
+            train_data_id='tmp_data_id',
+            callback=callback,
+            features=features,
+            feature_types=feature_types,
+            seed=seed,
+            k=k,
+            version=version)
+
+    def get_train_params(self):
+        """Using train_body to create the JSON request body for training.
+
+        Returns:
+            :obj:`dict`
+        """
+        setattr(self.train_body, 'train_data_id', self.data.id)
+        params = json.dumps(self.train_body.jsonable(), cls=CoreBody.ComplexEncoder)
         params = json.loads(params)
         return params

--- a/src/decanter/core/enums/evaluators.py
+++ b/src/decanter/core/enums/evaluators.py
@@ -29,6 +29,9 @@ class Evaluator(Enum):
         - auto (logloss)
         - logloss
         - misclassification
+    - Clustering
+        - auto (tot_withinss)
+        - tot_withinss
     """
     auto = 'auto'
     mse = 'mse'
@@ -44,6 +47,7 @@ class Evaluator(Enum):
     lift_top_group = 'lift_top_group'
     misclassification = 'misclassification'
     mean_per_class_error = 'mean_per_class_error'
+    tot_withinss = 'tot_withinss'
 
     @staticmethod
     def resolve_select_model_by(select_model_by, model_type):
@@ -52,6 +56,8 @@ class Evaluator(Enum):
                 return Evaluator.deviance.value
             elif model_type == "multinomial classification" or model_type == "binary classification":
                 return Evaluator.logloss.value
+            elif model_type == "clustering":
+                return Evaluator.tot_withinss.value
             else:
                 raise Exception(f"Illegal model type: {model_type}")
         else:

--- a/src/decanter/core/jobs/__init__.py
+++ b/src/decanter/core/jobs/__init__.py
@@ -1,6 +1,6 @@
 """Init jobs package"""
 from .data_upload import DataUpload
 from .data_setup import DataSetup
-from .experiment import Experiment, ExperimentTS
+from .experiment import Experiment, ExperimentTS, ExperimentCluster
 from .predict_result import PredictResult, PredictTSResult
 from .job import Job

--- a/src/decanter/core/jobs/experiment.py
+++ b/src/decanter/core/jobs/experiment.py
@@ -279,7 +279,7 @@ class ExperimentCluster(Experiment, Job):
             name (:obj:`str`, optional): (opt) Name to track Job progress
 
         Returns:
-            :class:`~decanter.core.jobs.experiment.ExperimentTS`: Experiment object\
+            :class:`~decanter.core.jobs.experiment.ExperimentCluster`: Experiment object\
                 with the specific id.
         """
         return super(ExperimentCluster, cls).create(exp_id=exp_id, name=name)

--- a/src/decanter/core/jobs/task.py
+++ b/src/decanter/core/jobs/task.py
@@ -204,6 +204,7 @@ class UploadTask(CoreTask):
     Attributes:
         file (csv-file-object): The csv file to be uploaded.
     """
+
     def __init__(self, file, name=None, eda=True):
         super().__init__(name=gen_id('UploadTask', name))
         self.file = file
@@ -226,6 +227,7 @@ class TrainTask(CoreTask):
         train_input (:class:`~decanter.core.core_api.train_input.TrainInput`):
             Settings for training.
     """
+
     def __init__(self, train_input, name=None):
         super().__init__(name=gen_id('TrainTask', name))
         self.train_input = train_input
@@ -243,6 +245,7 @@ class TrainTSTask(CoreTask):
         train_input (:class:`~decanter.core.core_api.train_input.TrainTSInput`):
             Settings for training time series forecast models.
     """
+
     def __init__(self, train_input, name=None):
         super().__init__(name=gen_id('TrainTSTask', name))
         self.train_input = train_input
@@ -255,6 +258,25 @@ class TrainTSTask(CoreTask):
             api_func=self.core_service.post_tasks_auto_ts_train, **train_params)
 
 
+class TrainClusterTask(CoreTask):
+    """Train time series forecast models on Decanter Core.
+
+    Attributes:
+        train_input (:class:`~decanter.core.core_api.train_input.TrainTSInput`):
+            Settings for training time series forecast models.
+    """
+
+    def __init__(self, train_input, name=None):
+        super().__init__(name=gen_id('TrainClusterTask', name))
+        self.train_input = train_input
+
+    def run(self):
+        """Execute clustering training by sending the cluster triain api."""
+        train_params = self.train_input.get_train_params()
+        super().run_core_task(
+            api_func=self.core_service.post_tasks_cluster_train, **train_params)
+
+
 class PredictTask(CoreTask):
     """Predict model on Decanter Core.
 
@@ -262,6 +284,7 @@ class PredictTask(CoreTask):
         predict_input (:class:`~decanter.core.core_api.predict_input.PredictInput`):
             Settings for prediction.
     """
+
     def __init__(self, predict_input, name=None):
         super().__init__(name=gen_id('PredictTask', name))
         self.predict_input = predict_input
@@ -282,6 +305,7 @@ class PredictTSTask(CoreTask):
             (:class:`~decanter.core.core_api.predict_input.PredictTSInput`):
             Settings for time series prediction.
     """
+
     def __init__(self, predict_input, name=None):
         super().__init__(name=gen_id('PredictTSTask', name))
         self.predict_input = predict_input
@@ -303,6 +327,7 @@ class SetupTask(CoreTask):
         setup_input (:class:`~decanter.core.core_api.setup_input.SetupInput`):
             Settings for set up data.
     """
+
     def __init__(self, setup_input, name='Setup'):
         super().__init__(name=name)
         self.setup_input = setup_input


### PR DESCRIPTION
Support train clustering experiment by TrainClusterInput and client.train_cluster
Example
```
from decanter.core.core_api import TrainClusterInput

train_input = TrainClusterInput(
            data=train_data,
            features=features,
            k=2
        )
exp = client.train_cluster(train_input=train_input, name="%s_train_experiment" % experiment)
client.run()
```