### PR TITLE
Add changed algo names and update the setup version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,39 @@
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 print(long_description)
 
 requires = [
-    'requests>=2.25.1',
-    'requests-toolbelt>=0.9.1',
-    'pandas>=1.3.0',
-    'matplotlib>=3.4.2',
-    'tqdm>=4.61.2',
-    'numpy>=1.21.0'
+    "requests>=2.25.1",
+    "requests-toolbelt>=0.9.1",
+    "pandas>=1.3.0",
+    "matplotlib>=3.4.2",
+    "tqdm>=4.61.2",
+    "numpy>=1.21.0",
 ]
 
-dev_requirements = [
-    'twine',
-    'tox',
-    'pytest',
-    'responses',
-    'flake8',
-    'pylint-quotes'
-]
+dev_requirements = ["twine", "tox", "pytest", "responses", "flake8", "pylint-quotes"]
 
 setuptools.setup(
-    name='decanter-ai-core-sdk',
-    author='Mobagel',
-    author_email='us@mobagel.com',
-    version='1.1.10',
-    license='MIT',
-    description='Decanter AI Core SDK for the easy use of Decanter Core API.',
+    name="decanter-ai-core-sdk",
+    author="Mobagel",
+    author_email="us@mobagel.com",
+    version="1.1.10",
+    license="MIT",
+    description="Decanter AI Core SDK for the easy use of Decanter Core API.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/MoBagel/decanter-ai-core-sdk',
+    long_description_content_type="text/markdown",
+    url="https://github.com/MoBagel/decanter-ai-core-sdk",
     packages=setuptools.find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=requires,
-    extras_require={
-        'dev': dev_requirements
-    },
-    test_suite='tests',
+    extras_require={"dev": dev_requirements},
+    test_suite="tests",
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent'
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7'
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     name='decanter-ai-core-sdk',
     author='Mobagel',
     author_email='us@mobagel.com',
-    version='1.1.8',
+    version='1.1.10',
     license='MIT',
     description='Decanter AI Core SDK for the easy use of Decanter Core API.',
     long_description=long_description,

--- a/src/decanter/core/enums/algorithms.py
+++ b/src/decanter/core/enums/algorithms.py
@@ -28,7 +28,8 @@ class Algo(Enum):
     - GBM: Gradient Boosting Machine.
     - XGBoost: eXtreme Gradient Boosting.
     - arima: auto arima (available only after 4.9 deployed with Exodus, only available for regression).
-    - prophet(=metaprophet): auto prophet (available only after 4.9 deployed with Exodus, only available for regression).
+    - prophet
+    (=metaprophet): auto prophet (available only after 4.9 deployed with Exodus, only available for regression).
     - theta: auto theta (available only after 4.9 deployed with Exodus, only available for regression).
     - ets: auto ets (available only after 4.10 deployed with Exodus, only available for regression).
     - lgbm_accuracy(=lgbmaccuracy)
@@ -66,5 +67,3 @@ class Algo(Enum):
     lgbmaccuracy = 'lgbmaccuracy'
     lgbmspeed = 'lgbmspeed'
     metaprophet = 'metaprophet'
-
-

--- a/src/decanter/core/enums/algorithms.py
+++ b/src/decanter/core/enums/algorithms.py
@@ -38,32 +38,32 @@ class Algo(Enum):
     - lstm
     """
 
-    '''
+    """
     These are the algorithm names for swarm mode decanter
-    '''
-    DRF = 'DRF'
-    GLM = 'GLM'
-    GBM = 'GBM'
-    DeepLearning = 'DeepLearning'
-    StackedEnsemble = 'StackedEnsemble'
-    XGBoost = 'XGBoost'
-    arima = 'arima'
-    prophet = 'prophet'
-    ets = 'ets'
-    theta = 'theta'
-    tpot = 'tpot'
-    lgbm_gpu = 'lgbm_gpu'
-    lgbm_speed = 'lgbm_speed'
-    lgbm_accuracy = 'lgbm_accuracy'
-    lstm = 'lstm'
-    few_shot_learning = 'few_shot_learning'
+    """
+    DRF = "DRF"
+    GLM = "GLM"
+    GBM = "GBM"
+    DeepLearning = "DeepLearning"
+    StackedEnsemble = "StackedEnsemble"
+    XGBoost = "XGBoost"
+    arima = "arima"
+    prophet = "prophet"
+    ets = "ets"
+    theta = "theta"
+    tpot = "tpot"
+    lgbm_gpu = "lgbm_gpu"
+    lgbm_speed = "lgbm_speed"
+    lgbm_accuracy = "lgbm_accuracy"
+    lstm = "lstm"
+    few_shot_learning = "few_shot_learning"
 
-    '''
+    """
     These are the algorithm names which is changed for K8S mode decanter
-    '''
-    autotpot = 'autotpot'
-    rfmulticlassifier = 'rfmulticlassifier'
-    fewshotlearning = 'fewshotlearning'
-    lgbmaccuracy = 'lgbmaccuracy'
-    lgbmspeed = 'lgbmspeed'
-    metaprophet = 'metaprophet'
+    """
+    autotpot = "autotpot"
+    rfmulticlassifier = "rfmulticlassifier"
+    fewshotlearning = "fewshotlearning"
+    lgbmaccuracy = "lgbmaccuracy"
+    lgbmspeed = "lgbmspeed"
+    metaprophet = "metaprophet"

--- a/src/decanter/core/enums/algorithms.py
+++ b/src/decanter/core/enums/algorithms.py
@@ -18,7 +18,8 @@ class Algo(Enum):
     - DeepLearning: Deep Learning.
     - StackedEnsemble: Stacked Ensemble.
     - XGBoost: eXtreme Gradient Boosting.
-    - tpot: Tree-based Pipeline Optimization Tool. (available only after 4.10 deployed with Exodus).
+    - tpot(autotpot): Tree-based Pipeline Optimization Tool. (available only after 4.10 deployed with Exodus).
+    - rfmulticlassifier
 
     TrainTSInput (used by client.train_ts) supported algorithms
 
@@ -27,10 +28,18 @@ class Algo(Enum):
     - GBM: Gradient Boosting Machine.
     - XGBoost: eXtreme Gradient Boosting.
     - arima: auto arima (available only after 4.9 deployed with Exodus, only available for regression).
-    - prophet: auto prophet (available only after 4.9 deployed with Exodus, only available for regression).
+    - prophet(=metaprophet): auto prophet (available only after 4.9 deployed with Exodus, only available for regression).
     - theta: auto theta (available only after 4.9 deployed with Exodus, only available for regression).
     - ets: auto ets (available only after 4.10 deployed with Exodus, only available for regression).
+    - lgbm_accuracy(=lgbmaccuracy)
+    - lgbm_speed(=lgbmspeed)
+    - few_shot_learning(=fewshotlearning)
+    - lstm
     """
+
+    '''
+    These are the algorithm names for swarm mode decanter
+    '''
     DRF = 'DRF'
     GLM = 'GLM'
     GBM = 'GBM'
@@ -43,3 +52,19 @@ class Algo(Enum):
     theta = 'theta'
     tpot = 'tpot'
     lgbm_gpu = 'lgbm_gpu'
+    lgbm_speed = 'lgbm_speed'
+    lgbm_accuracy = 'lgbm_accuracy'
+    lstm = 'lstm'
+    few_shot_learning = 'few_shot_learning'
+
+    '''
+    These are the algorithm names which is changed for K8S mode decanter
+    '''
+    autotpot = 'autotpot'
+    rfmulticlassifier = 'rfmulticlassifier'
+    fewshotlearning = 'fewshotlearning'
+    lgbmaccuracy = 'lgbmaccuracy'
+    lgbmspeed = 'lgbmspeed'
+    metaprophet = 'metaprophet'
+
+


### PR DESCRIPTION
Add the changed algorithm names and the new algo name of K8S decanter ai.
The names is according to this ticket's image.
https://mobagel.atlassian.net/browse/DE-6822

The version before this commit should be 1.1.9, so the new version should be 1.1.10.

 